### PR TITLE
Feature/dev 2.x.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ var viewHelper = function () {
         view.once('destroy', function() {
             parentView.off('render', onRender);
             parentView.off('destroy', onDestroy);
-            delete parentView[name];
+            parentView.regionManager.removeRegion(name);
         });
     } else {
         console.warn('Cannot find "view" for handlebars view helper "' + name + '"');

--- a/index.js
+++ b/index.js
@@ -90,12 +90,13 @@ var viewHelper = function () {
     }
 
     if (parentView) {
+        var view = new View(hash);
         var onRender = function () {
             if (!parentView[name]) {
                 console.error('Region is not initialized, may be view is destroyed');
             }
             else {
-                parentView[name].show(new View(hash));
+                parentView[name].show(view);
             }
         };
 
@@ -105,6 +106,12 @@ var viewHelper = function () {
 
         parentView.once('render', onRender);
         parentView.once('destroy', onDestroy);
+        
+        view.once('destroy', function() {
+            parentView.off('render', onRender);
+            parentView.off('destroy', onDestroy);
+            delete parentView[name];
+        });
     } else {
         console.warn('Cannot find "view" for handlebars view helper "' + name + '"');
     }


### PR DESCRIPTION
Дано: какая-то сложная вьюха, слушающая изменения модельки и делающая render по изменению в ней. 
Проблема: при ререндере у вьюхи накапливается мусор в виде полей injectifyXXX, и если вьюха будет висеть долго (день и более) - то этот мусор сжирает всю память. 
Решение: при ререндере отдестроенные чилды отцеплять от вьюхи подчищая вот эти injectifyXXX (ну и замыкания еще).