### PR TITLE
destroy child event

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ var viewHelper = function () {
             else {
                 var view = new View(hash);
                 view.once('destroy', function () {
-                    parentView.trigger('destroy:child:' + name);
+                    parentView.off('destroy', onDestroy);
+                    parentView.regionManager.removeRegion(name);
                 });
                 parentView[name].show(view);
             }
@@ -105,17 +106,10 @@ var viewHelper = function () {
 
         var onDestroy = function () {
             parentView.off('render', onRender);
-            parentView.off('destroy:child:' + name);
-        };
-
-        var onDestroyChild = function () {
-            parentView.off('destroy', onDestroy);
-            parentView.regionManager.removeRegion(name);
         };
 
         parentView.once('render', onRender);
         parentView.once('destroy', onDestroy);
-        parentView.once('destroy:child:' + name, onDestroyChild);
     } else {
         console.warn('Cannot find "view" for handlebars view helper "' + name + '"');
     }


### PR DESCRIPTION
Проблема: предыдущая версия ломает пользовательские сценарии, когда при инициализации вьюхи устанавливаются листенеры, которые думают что вьюха уже отрендерена/отработан bindUIElements. Справедлив ли такой сценарий - вопрос спорный, но раз уж есть привычка в блоке initialize ставить такие листенеры, как fromModelToView и ожидать что секция ui уже забинжена, то есть резон не портить людям жизнь.
Решение: ничего лучше не придумал, как оставить инициализацию там где была и тригерить в parentView событие destroy:child:injectifyXXX. Как то явно чистить onDestroy в блоке onRender, который стоит перед инициализацией onDestroy, у меня не вышло.